### PR TITLE
Kiknos NSE NAT support

### DIFF
--- a/examples/ucnf-kiknos/Makefile
+++ b/examples/ucnf-kiknos/Makefile
@@ -2,7 +2,7 @@ include $(TOP)/mk/targets.mk
 
 CLUSTER1?=kiknos-demo-1
 CLUSTER2?=kiknos-demo-2
-ORG=mmatache
+ORG=rastislavszabo
 AWS_KEY_PAIR?=kiknos-asa
 
 

--- a/examples/ucnf-kiknos/helm/istio_ingress/templates/istio-ingress.yaml
+++ b/examples/ucnf-kiknos/helm/istio_ingress/templates/istio-ingress.yaml
@@ -35,7 +35,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
   annotations:
-    ns.networkservicemesh.io: {{ .Values.nsm.serviceName }}?nat-port-forward=80
+    ns.networkservicemesh.io: {{ .Values.nsm.serviceName }}?nat-port-forward-tcp=80
 spec:
   selector:
     matchLabels:

--- a/examples/ucnf-kiknos/helm/istio_ingress/templates/istio-ingress.yaml
+++ b/examples/ucnf-kiknos/helm/istio_ingress/templates/istio-ingress.yaml
@@ -35,7 +35,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
   annotations:
-    ns.networkservicemesh.io: {{ .Values.nsm.serviceName }}
+    ns.networkservicemesh.io: {{ .Values.nsm.serviceName }}?nat-port-forward=80
 spec:
   selector:
     matchLabels:

--- a/examples/ucnf-kiknos/helm/kiknos_vpn_endpoint/templates/kiknos-nse-ucnf.yaml
+++ b/examples/ucnf-kiknos/helm/kiknos_vpn_endpoint/templates/kiknos-nse-ucnf.yaml
@@ -58,6 +58,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            {{- if .Values.ucnf.natIP }}
+            - name: NSE_NAT_IP
+              value: "{{ .Values.ucnf.natIP }}"
+            {{- end }}
             - name: MICROSERVICE_LABEL
               value: {{ .Values.aio.serviceLabel }}
           securityContext:
@@ -193,7 +197,7 @@ data:
       labels:
         app: "vl3-nse-{{ .Values.nsm.serviceName }}"
       ipam:
-        prefixpool: {{ .Values.strongswan.network.localSubnet | quote }}
+        prefixpool: {{ .Values.ucnf.localSubnet | quote }}
         routes: {{ .Values.strongswan.network.remoteSubnets | toJson }}
       ifname: "endpoint0"
 
@@ -252,18 +256,21 @@ data:
     client-basic-auth:
       - {{ .Values.aio.http.secrets.basicAuth | quote }}
     {{- end }}
-  {{- if .Values.strongswan.secrets.encryption.enabled }}
-  kiknos.conf: |
-    KiknosConfig:
+  kiknoscfg.conf: |
+    kiknosConfig:
+      {{- if .Values.ucnf.natIP }}
+      natOutside: true
+      {{- end }}
+      {{- if .Values.strongswan.secrets.encryption.enabled }}
       secretsKeyFile: /var/strongswan/secrets/{{ .Values.strongswan.secrets.encryption.privateKeyFile }}
-  {{- end }}
+      {{- end }}
   supervisor.conf: |
     programs:
       - name: "vpp"
         executable-path: "/usr/bin/vpp"
         executable-args: ["-c", "/etc/vpp/vpp.conf"]
       - name: "aio-agent"
-        executable-path: "{{if.Values.development.useDevImages}}/go/bin/{{else}}/usr/bin/{{end}}aio-agent"
+        executable-path: "{{if.Values.development.useDevImages}}/go/bin/{{else}}/usr/bin/{{end}}aio-sswan-agent"
         executable-args: ["--config-dir=/opt/aio-agent/dev"]
       - name: "strongswan"
         executable-path: "/usr/local/libexec/ipsec/charon"

--- a/examples/ucnf-kiknos/helm/kiknos_vpn_endpoint/templates/kiknos-nse-ucnf.yaml
+++ b/examples/ucnf-kiknos/helm/kiknos_vpn_endpoint/templates/kiknos-nse-ucnf.yaml
@@ -192,6 +192,12 @@ metadata:
   name: ucnf-kiknos-{{ .Values.nsm.serviceName }}
 data:
   config.yaml: |
+    {{- if .Values.ucnf.natIP }}
+    initactions:
+    - dpconfig:
+        nat44pools:
+        - firstip: {{ .Values.ucnf.natIP }}
+    {{- end }}
     endpoints:
     - name: {{ .Values.nsm.serviceName | quote }}
       labels:

--- a/examples/ucnf-kiknos/helm/kiknos_vpn_endpoint/templates/vpp-cfg.yaml
+++ b/examples/ucnf-kiknos/helm/kiknos_vpn_endpoint/templates/vpp-cfg.yaml
@@ -25,3 +25,6 @@ data:
         disable
       }
     }
+    nat {
+      endpoint-dependent
+    }

--- a/examples/ucnf-kiknos/helm/kiknos_vpn_endpoint/values.yaml
+++ b/examples/ucnf-kiknos/helm/kiknos_vpn_endpoint/values.yaml
@@ -20,6 +20,10 @@ ipam:
   prefixPool: "172.31.0.0/16"
   # uniqueOctet:
 
+ucnf:
+  localSubnet: 172.31.22.0/24
+  natIP:
+
 global:
 
 replicaCount: 1

--- a/examples/ucnf-kiknos/scripts/day0.txt
+++ b/examples/ucnf-kiknos/scripts/day0.txt
@@ -27,7 +27,7 @@ username admin nopassword privilege 15
 username admin attributes
 service-type admin
 !
-access-list ikev2-list extended permit ip <HOST_NETWORK> 255.255.255.0 172.31.22.0 255.255.255.0
+access-list ikev2-list extended permit ip <HOST_NETWORK> 255.255.255.0 1.2.3.4 255.255.255.255
 crypto ipsec ikev2 ipsec-proposal ikev2-proposal                                                                                                                                                              
  protocol esp encryption aes                                                                                                                                                                                  
  protocol esp integrity sha-1                                                                                                                                                                                 

--- a/examples/ucnf-kiknos/scripts/start_topo.sh
+++ b/examples/ucnf-kiknos/scripts/start_topo.sh
@@ -3,7 +3,7 @@
 # Topology information
 CLUSTER1=${CLUSTER1:-kiknos-demo-1}
 CLUSTER2=${CLUSTER2:-kiknos-demo-2}
-VPP_AGENT=${VPP_AGENT:-rastislavszabo/kiknos-sswan:latest}
+VPP_AGENT=${VPP_AGENT:-ciscolabs/kiknos-sswan:latest}
 NSE_ORG=${NSE_ORG:-rastislavszabo}
 NSE_TAG=${NSE_TAG:-kiknos}
 PULL_POLICY=${PULL_POLICY:-IfNotPresent}

--- a/examples/ucnf-kiknos/scripts/start_topo.sh
+++ b/examples/ucnf-kiknos/scripts/start_topo.sh
@@ -3,8 +3,8 @@
 # Topology information
 CLUSTER1=${CLUSTER1:-kiknos-demo-1}
 CLUSTER2=${CLUSTER2:-kiknos-demo-2}
-VPP_AGENT=${VPP_AGENT:-ciscolabs/kiknos:latest}
-NSE_ORG=${NSE_ORG:-mmatache}
+VPP_AGENT=${VPP_AGENT:-rastislavszabo/kiknos-sswan:latest}
+NSE_ORG=${NSE_ORG:-rastislavszabo}
 NSE_TAG=${NSE_TAG:-kiknos}
 PULL_POLICY=${PULL_POLICY:-IfNotPresent}
 SERVICE_NAME=${SERVICE_NAME:-icmp-responder}
@@ -266,8 +266,8 @@ if [ "$BUILD_IMAGE" == "true" ]; then
   fi
 fi
 
-performNSE "$CLUSTER1" $OPERATION --set strongswan.network.localSubnet=172.31.22.0/24 \
-  --set strongswan.network.remoteSubnets="{172.31.23.0/24,192.168.254.0/24}"
+performNSE "$CLUSTER1" $OPERATION --set ucnf.localSubnet=172.31.22.0/24 --set strongswan.network.localSubnet=1.2.3.4/32 \
+  --set strongswan.network.remoteSubnets="{172.31.23.0/24,192.168.254.0/24}" --set ucnf.natIP=1.2.3.4
 
 echo "# Retrieving IP and MAC addr of interface"
 INTERFACE="global eth0"
@@ -289,8 +289,8 @@ if [ "$DEPLOY_ASA" == "true" ] && [ "$AWS" == "true" ]; then
 fi
 
 performNSE "$CLUSTER2" $OPERATION --set strongswan.network.remoteAddr="$IP_ADDR" \
-  --set strongswan.network.localSubnet=172.31.23.0/24 \
-  --set strongswan.network.remoteSubnets="{172.31.22.0/24}"
+  --set ucnf.localSubnet=172.31.23.0/24  --set strongswan.network.localSubnet=172.31.23.0/24 \
+  --set strongswan.network.remoteSubnets="{1.2.3.4/32}"
 
 if [ "$NO_ISTIO" == "false" ]; then
   echo "Installing Istio control plane"


### PR DESCRIPTION
Source NAT on IPSec tunnel interfaces can be enabled with the helm option `ucnf.natIP`. Its value should contain the requested outside NAT IP address, e.g. `ucnf.natIP=1.2.3.4`.

Enabling NAT results into the following configuration on the NSE VPP:

- each NSC-facing interface is configured as "NAT inside"
- each IPSec (IPIP) tunnel interface is configured as "NAT outside"

```
vpp# sh nat44 interfaces                                                                                                                                                                                      
NAT44 interfaces:                                                                                                                                                                                             
 memif1/0 in                                                                                                                                                                                                  
 memif2/0 in                                                                                                                                                                                                  
 memif3/0 in                                                                                                                                                                                                  
 ipip0 out   
```

NAT pool is configured to the NAT IP provided in the `ucnf.natIP` helm option:

```
vpp# sh nat44 addresses 
NAT44 pool addresses:
1.2.3.4
  tenant VRF: 0
  0 busy other ports
  0 busy udp ports
  0 busy tcp ports                                                                                                                                                                                            
  0 busy icmp ports 
```

At this point, every conection from inside (NSCs) to outside (remote IPSec peers) is source-NATed to the configured NAT IP. Connections from outside to inside are not allowed (not to NAT IP nor NSC IPs). To allow outside-to-inside connections, NSC has to request forwarding of a specific TCP/UDP port to them. They can do it with lables in `networkservicemesh.io` annotations, e.g. 
`ns.networkservicemesh.io: nsm-service-name?nat-port-forward-tcp=80` to forward TCP port 80, or `ns.networkservicemesh.io: nsm-service-name?nat-port-forward-udp=53`
to port forward UDP port 53.


That renders into a static nat44 mapping configuration on VPP, e.g.:

```
vpp# sh nat44 static mappings                                                                                                                                                                                                               
NAT44 static mappings:                                                                                                                                                                                                                      
 tcp local 172.31.22.9:80 external 1.2.3.4:80 vrf 0  out2in-only                                                                                                                                                                            
```

In our setup, the Istio NSC requests port forwarding on port 80 with `ns.networkservicemesh.io: {{ .Values.nsm.serviceName }}?nat-port-forward-tcp=80`, which means that remote IPSec peers can access the Istio ingress gateway running in the cluster at `http://1.2.3.4:80`.
